### PR TITLE
index files with absolute path

### DIFF
--- a/hydromosaic/indexing/index_netCDF.py
+++ b/hydromosaic/indexing/index_netCDF.py
@@ -229,7 +229,7 @@ def index_directory(dsn, directory, log_level, gcm_prefix):
             # database objects derived from nc file data
             outlets = get_outlets(nc, session)
             variables = get_variables(nc, session)
-            datafile = get_datafile(f"{directory.strip('/')}/{file}", session)
+            datafile = get_datafile(os.path.abspath(f"{directory.strip('/')}/{file}"), session)
             start, end, num_times = get_timespan(nc)
 
             # flush objects so that they get primary keys assigned before


### PR DESCRIPTION
Fixing a bug that became apparent when working on streaming data from the files. 

**Before**:

```sql 
SELECT * FROM hydromosaic.datafiles
```

| datafile_id | filename                                         | index_time |
|-------------|--------------------------------------------------|------------|
| 14          | "../data/out.ncdf.26all/ALOUETTE_Hydrographs.nc" | 2025-02-18 |

**After**: 
```sql 
SELECT * FROM hydromosaic.datafiles
```

| datafile_id | filename                                         | index_time |
|-------------|--------------------------------------------------|------------|
| 15          | "/home/lzeman/Code/hmdb/data/out.ncdf.26all/ALOUETTE_Hydrographs.nc" | 2025-02-26 |

resolves #6 