### PR TITLE
Handle data paths that begin with a slash correctly

### DIFF
--- a/hydromosaic/indexing/index_netCDF.py
+++ b/hydromosaic/indexing/index_netCDF.py
@@ -229,7 +229,7 @@ def index_directory(dsn, directory, log_level, gcm_prefix):
             # database objects derived from nc file data
             outlets = get_outlets(nc, session)
             variables = get_variables(nc, session)
-            datafile = get_datafile(os.path.abspath(f"{directory.strip('/')}/{file}"), session)
+            datafile = get_datafile(os.path.abspath(f"{directory.rstrip('/')}/{file}"), session)
             start, end, num_times = get_timespan(nc)
 
             # flush objects so that they get primary keys assigned before

--- a/hydromosaic/indexing/index_netCDF.py
+++ b/hydromosaic/indexing/index_netCDF.py
@@ -229,7 +229,7 @@ def index_directory(dsn, directory, log_level, gcm_prefix):
             # database objects derived from nc file data
             outlets = get_outlets(nc, session)
             variables = get_variables(nc, session)
-            datafile = get_datafile(os.path.abspath(f"{directory.rstrip('/')}/{file}"), session)
+            datafile = get_datafile(os.path.abspath(os.path.join(directory, file)), session)
             start, end, num_times = get_timespan(nc)
 
             # flush objects so that they get primary keys assigned before
@@ -266,6 +266,7 @@ def index_directory(dsn, directory, log_level, gcm_prefix):
     )
     for file in indexed:
         logger.debug("{} was indexed".format(file))
-    logger.error("The following files could not be indexed:")
-    for file in unindexable:
-        logger.error(f"{file}: {unindexable[file]}")
+    if len(unindexable):
+        logger.error("The following files could not be indexed:")
+        for file in unindexable:
+            logger.error(f"{file}: {unindexable[file]}")


### PR DESCRIPTION
Ran into a second pathing bug. I used `string.strip()` to remove the trailing slash from the directory command line argument if provided, in order to make things function equivalently whether the user used a trailing slash or not. 

However, if your directory _starts_ with a slash, like `/storage/...`, the initial slash will be removed by `strip()` as well, and the directory will be interpreted and recorded in the database as a subdirectory named `storage` inside the working directory. 

Switched to `rstrip()` to remove only a trailing slash, and leave initial slashes alone.